### PR TITLE
Fix timer state and directory recursion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# For next release
+  * **Tom Siewert**
+    * tasks: Set timer state to started or stopped
+      
+      Even if the timer is enabled, systemd will not generate certificates
+      until the system has been rebooted or the timer has been started
+      directly.
+
+*Not released yet*
+
 # Patch Release v1.0.1 (2023-02-07)
   * **Tom Siewert**
     * meta: Use correct license

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
       Even if the timer is enabled, systemd will not generate certificates
       until the system has been rebooted or the timer has been started
       directly.
+    * tasks: Do not recurse on directory task
+
+      Ansible does not only recurse on the directory inodes, but also on the
+      files in these directories. Due to this behaviour, Ansible sets the permission
+      of all created certificates to 0755.
 
 *Not released yet*
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,4 +67,5 @@
 - name: "Ensure systemd timer is {{ 'enabled' if ipxe_ca__systemd_timer_enabled else 'disabled' }}"
   ansible.builtin.systemd:
     name: ipxe-ca-sign.timer
+    state: "{{ 'started' if ipxe_ca__systemd_timer_enabled else 'stopped' }}"
     enabled: "{{ ipxe_ca__systemd_timer_enabled }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,9 +9,14 @@
 
 - name: Ensure iPXE CA web path exists
   ansible.builtin.file:
+    path: "{{ ipxe_ca__web_path }}"
+    state: directory
+    mode: '0755'
+
+- name: Ensure iPXE CA web sub-directories exist
+  ansible.builtin.file:
     path: "{{ ipxe_ca__web_path }}/{{ item }}"
     state: directory
-    recurse: true
     mode: '0755'
   loop:
     - auto


### PR DESCRIPTION
Ansible does not only recurse on the directory inodes, but also on the
files in these directories. Due to this behaviour, Ansible sets the
permission of all created certificates to 0755.

For the timer part: Even if the timer is enabled, systemd will not generate
certificates until then system has been rebooted or the timer has been
started directly.