### PR TITLE
Dangerfile: Add missing has_app_changes method

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,12 +1,14 @@
 # -*- mode: ruby -*- vim: set syntax=ruby
 # frozen_string_literal: true
 
+has_app_changes = !git.modified_files.grep(/(files|defaults|tasks|handlers|meta|templates)/).empty?
+
 if git.commits.any? { |c| c.message =~ /^Merge branch/ }
   fail('Please rebase to get rid of the merge commits in this PR!')
   message "For more information, please see [man git-rebase](https://git-scm.com/docs/git-rebase)."
 end
 
-if !git.modified_files.include?("CHANGELOG.md") && !has_app_changes
+if !git.modified_files.include?("CHANGELOG.md") && has_app_changes
   fail("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/hetznercloud/ansible-role-ipxe-ca/blob/main/CHANGELOG.md).")
   message "Note, we use [changelogger](https://github.com/MarkusFreitag/changelogger) as changelog tooling."
 end


### PR DESCRIPTION
This commit fixes the Danger bot which throws an error if CHANGELOG.md isn't modified. The initial idea was that only a changelog entry is needed if the role code has changed however, it was somehow missed to add the proper method for it.