### PR TITLE
ci: Run GH workflows on public workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -27,7 +27,7 @@ jobs:
 
   molecule:
     name: Molecule
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   danger:
     name: Danger
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
The self-hosted runner cluster "Rudibert" will be decomissioned for internal reasons. Therefore, the workflows need to run on public workers. It is possible that, due to that, the molecule job may fail for external contributors because the TTS token will be set via an environment variable in the project settings and not via the worker settings anymore.