### PR TITLE
github: codeowners: rename team

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -14,3 +14,5 @@ exclude_paths:
   - molecule/default/converge.yml
   - .git/
   - .cache/
+  - .github/
+  - .gitlab-ci.yml

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hetznercloud/ops-fsn
+* @hetznercloud/platform-ops


### PR DESCRIPTION
The previously named team "Team Falkenstein" has been renamed to "Platform Ops" a while ago.

To keep it generic internal and external, the team has been renamed on GitHub too.