### PR TITLE
test: upgrade molecule-hetznercloud to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Install yamllint
         run: pip3 install ansible-lint yamllint
@@ -40,10 +40,10 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Install ansible and molecule
-        run: pip3 install ansible "ansible-compat<4" molecule-hetznercloud
+        run: pip3 install ansible 'molecule>=6.0,<7.0' 'molecule-hetznercloud>=2.0,<3.0'
 
       - uses: hetznercloud/tps-action@main
         with:
@@ -53,6 +53,5 @@ jobs:
         run: |
           molecule test
         env:
-          TTS_TOKEN: ${{ secrets.TTS_TOKEN }}
-          PY_COLORS: '1'
-          ANSIBLE_FORCE_COLOR: '1'
+          PY_COLORS: "1"
+          ANSIBLE_FORCE_COLOR: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install ansible and molecule
-        run: pip3 install ansible 'molecule>=6.0,<7.0' 'https://github.com/ansible-community/molecule-hetznercloud/archive/main.zip'
+        run: pip3 install ansible 'molecule>=6.0,<7.0' 'molecule-hetznercloud>=2.0,<3.0'
 
       - uses: hetznercloud/tps-action@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install ansible and molecule
-        run: pip3 install ansible 'molecule>=6.0,<7.0' 'molecule-hetznercloud>=2.0,<3.0'
+        run: pip3 install ansible 'molecule>=6.0,<7.0' 'https://github.com/ansible-community/molecule-hetznercloud/archive/main.zip'
 
       - uses: hetznercloud/tps-action@main
         with:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,11 +5,10 @@ dependency:
   name: galaxy
 
 driver:
-  name: hetznercloud
+  name: molecule_hetznercloud
 
 platforms:
-  - name: ipxe-ca-default-jammy
-    server_type: cx11
+  - name: ipxe-ca-jammy-1
     image: ubuntu-22.04
     location: fsn1
 

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -11,7 +11,7 @@
       ansible.builtin.copy:
         src: "files/{{ item }}"
         dest: "/etc/ssl/private/{{ item }}"
-        mode: '0644'
+        mode: "0644"
       no_log: true
       loop:
         - ipxe.crt


### PR DESCRIPTION
This PR will help me iron out any bug present in the rewrite of the molecule driver.

- upgrade molecule-hetznercloud to v2
  - platforms `server_type` now defaults to `cx11`
  - the driver name was renamed to molecule_hetznercloud
  - each resource (servers, volumes, networks) are name spaced per role/scenario, so you may reuse instance names across scenarios
- upgrade molecule to v6 (you may pin the version to v5 if needed)
- remove TTS leftover